### PR TITLE
switched to absolute path for course images

### DIFF
--- a/_includes/get-course.html
+++ b/_includes/get-course.html
@@ -17,7 +17,7 @@
     <div class="card-img">
       {% if course.image %} 
       	<a href="{{ course.url | relative_url}}">
-      		<img src="{{ course.image | prepend: '/assets/images/' | relative_url}}"/>
+      		<img src="{{ course.image | relative_url}}"/>
       	</a>
       {% endif %}
     </div>

--- a/_layouts/course.html
+++ b/_layouts/course.html
@@ -38,7 +38,7 @@ layout: default
 
     <div class="column column-33 ">
       <div class="page-img full-width">
-        {% if page.image %} <img src="{{ page.image | prepend: '/assets/images/' | relative_url}}"/> {% endif %}
+        {% if page.image %} <img src="{{ page.image | relative_url}}"/> {% endif %}
       </div>
     </div>
 	</div>

--- a/_teaching/bigcode18-ss.html
+++ b/_teaching/bigcode18-ss.html
@@ -12,7 +12,7 @@ session-time-place: Mon 16-18, CHN D48
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/bigcode18.html
+++ b/_teaching/bigcode18.html
@@ -12,7 +12,7 @@ session-time-place: Mon 16-18, CAB G52
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/bigcode19-fall.html
+++ b/_teaching/bigcode19-fall.html
@@ -12,7 +12,7 @@ session-time-place: Mon 16-18, CAB G52
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/bigcode19.html
+++ b/_teaching/bigcode19.html
@@ -12,7 +12,7 @@ session-time-place: Mon 16-18, CAB G52
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/bigcode20.html
+++ b/_teaching/bigcode20.html
@@ -12,7 +12,7 @@ session-time-place: Mon 16-18, CAB G52
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/bsec2018-ss.html
+++ b/_teaching/bsec2018-ss.html
@@ -12,7 +12,7 @@ session-time-place: Fri 13-15, CHN G22
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/bsec2018.html
+++ b/_teaching/bsec2018.html
@@ -12,7 +12,7 @@ session-time-place: Wed 13-15, LFW B 3
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: bsec.jpg
+image: assets/images/bsec.jpg
 
 ---
 

--- a/_teaching/bsec2019-fall.html
+++ b/_teaching/bsec2019-fall.html
@@ -13,7 +13,7 @@ session-time-place: Wed 13-15, LFW B3
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: bsec.jpg
+image: assets/images/bsec.jpg
 
 ---
 

--- a/_teaching/bsec2019.html
+++ b/_teaching/bsec2019.html
@@ -13,7 +13,7 @@ session-time-place: Fri 13-15, CAB G57
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: bsec.jpg
+image: assets/images/bsec.jpg
 
 ---
 

--- a/_teaching/pa2013.html
+++ b/_teaching/pa2013.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Wed 9-11, CHN D46
 exercise-time-place: 
 credits: 4
-image: gears.jpeg
+image: assets/images/gears.jpeg
 
 ---
 

--- a/_teaching/pa2015.html
+++ b/_teaching/pa2015.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Thu 13:15-15:00, ML F38
 exercise-time-place: 
 credits: 4
-image: gears.jpeg
+image: assets/images/gears.jpeg
 
 ---
 

--- a/_teaching/pa2016.html
+++ b/_teaching/pa2016.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Mon 13-16, CAB G51
 exercise-time-place: 
 credits: 6
-image: gears.jpeg
+image: assets/images/gears.jpeg
 
 ---
 

--- a/_teaching/pa2017.html
+++ b/_teaching/pa2017.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Mon 13-16, CAB G51
 exercise-time-place: 
 credits: 6
-image: gears.jpeg
+image: assets/images/gears.jpeg
 
 ---
 

--- a/_teaching/pass2018.html
+++ b/_teaching/pass2018.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Mon 13-15, CAB G61
 exercise-time-place: Mon 15-16, CAB G61
 credits: 5
-image: pass.png
+image: assets/images/pass.png
 
 ---
 

--- a/_teaching/pass2019.html
+++ b/_teaching/pass2019.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Mon 13-15, CAB G61
 exercise-time-place: Mon 15-16, CAB G61
 credits: 5
-image: pass.png
+image: assets/images/pass.png
 
 ---
 

--- a/_teaching/pass2020.html
+++ b/_teaching/pass2020.html
@@ -11,7 +11,7 @@ edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitI
 session-time-place:
 lecture-time-place: Mon 14-16, &nbsp; <a href="https://ethz.zoom.us/j/956696654">Zoom</a> &nbsp;  (Meeting ID&#58;	 956-696-654)
 exercise-time-place: Tue 15-16, &nbsp;  <a href="https://ethz.zoom.us/j/705117847"> Zoom</a> &nbsp;  (Meeting ID&#58;	 705-117-847)
-image: pass.png
+image: assets/images/pass.png
 credits: 6
 
 ---

--- a/_teaching/pl2013.html
+++ b/_teaching/pl2013.html
@@ -12,7 +12,7 @@ session-time-place: Tue 13-15, CAB H53
 lecture-time-place: 
 exercise-time-place: 
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/pp2017.html
+++ b/_teaching/pp2017.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Tue	10-12 and Wed 13-15 [ETF E 1]
 exercise-time-place: Wed 15-17 or Fri 10-12
 credits: 
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/pp2018.html
+++ b/_teaching/pp2018.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Tue	10-12, ML D 28; Wed 13-15, HG F 5
 exercise-time-place: Wed 15-17 or Fri 10-12
 credits:
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/pp2019.html
+++ b/_teaching/pp2019.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Tue	10-12, ML D 28 (Video Projection in ML E 12); Wed 13-15, HG F 7 (Video Projection in HG F 5)
 exercise-time-place: Wed 15-17 or Fri 10-12
 credits:
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/ps2014.html
+++ b/_teaching/ps2014.html
@@ -12,7 +12,7 @@ session-time-place: Tue 13-15, CAB H53
 lecture-time-place: 
 exercise-time-place: 
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/riai2017.html
+++ b/_teaching/riai2017.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Tue 10-12, HG E3
 exercise-time-place: Tue 14-15, HG F26.3; Wed 11-12, CAB G59
 credits: 4
-image: ai.png
+image: assets/images/ai.png
 
 ---
 

--- a/_teaching/riai2018.html
+++ b/_teaching/riai2018.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Mon 10-12, HG D 7.2
 exercise-time-place: Mon 13-14, LFW C4 or Wed 11-12 CAB G59
 credits: 4
-image: ai.png
+image: assets/images/ai.png
 ---
 
 <h2>Overview</h2>

--- a/_teaching/riai2019.html
+++ b/_teaching/riai2019.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Wed 15-17, HG G 3
 exercise-time-place: Mon 13-14, LFW C4 or Wed 11-12 CAB G59
 credits: 5
-image: ai.png
+image: assets/images/ai.png
 ---
 
 <h2>Overview</h2>

--- a/_teaching/riai2020.html
+++ b/_teaching/riai2020.html
@@ -14,7 +14,7 @@ session-time-place:
 lecture-time-place: Wed 14-16, Online
 exercise-time-place: Mon 12-14, CAB G56 or Wed 12-14 CAB G51
 credits: 6
-image: riai_logo_1200_630.png
+image: assets/images/riai_logo_1200_630.png
 ---
 
 <h2>Overview</h2>

--- a/_teaching/rse-fall2016.html
+++ b/_teaching/rse-fall2016.html
@@ -12,7 +12,7 @@ session-time-place: Wed 10-12, CHN D46
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/rse-spr2016.html
+++ b/_teaching/rse-spr2016.html
@@ -12,7 +12,7 @@ session-time-place: Mon 16-18, CHN D 48
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/rse2019.html
+++ b/_teaching/rse2019.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Mon 10-12, CAB G61; Wed 10-12, CAB G61
 exercise-time-place: Mon 13-16, HG D3.2; Tue 15-18, ML E12; Thu 15-18, ML H41.1
 credits: 8
-image: sae.png
+image: assets/images/sae.png
 
 ---
 

--- a/_teaching/sae2018.html
+++ b/_teaching/sae2018.html
@@ -12,7 +12,7 @@ session-time-place:
 lecture-time-place: Mon 10-12, CAB G61; Wed 10-12, CAB G61
 exercise-time-place: Mon 13-16, CHN D44; Tue 15-18, ML E12; Thu 15-18, ETZ F91
 credits: 8
-image: sae.png
+image: assets/images/sae.png
 
 ---
 

--- a/_teaching/ses2018.html
+++ b/_teaching/ses2018.html
@@ -12,7 +12,7 @@ session-time-place: Mon 13-15, CHN G46
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 

--- a/_teaching/ses2020.html
+++ b/_teaching/ses2020.html
@@ -13,7 +13,7 @@ session-time-place: Tue 14-16, Online on&nbsp;<a href="https://ethz.zoom.us/j/91
 lecture-time-place:
 exercise-time-place:
 credits: 2
-image: orator.jpg
+image: assets/images/orator.jpg
 
 ---
 


### PR DESCRIPTION
We can check that there are no old image tags left by running:

```
grep -r "image:.." _teaching | grep -v "assets/images"
```