### PR TITLE
Clean up and unify the use of rooms, add links

### DIFF
--- a/_people/anouk.html
+++ b/_people/anouk.html
@@ -3,7 +3,7 @@ title: Dr. Anouk Paradis
 position: Post-Doc
 image: anouk.jpg
 email: anouk.paradis@inf.ethz.ch
-office: CNB H 100.5
+office: <a href="https://ethz.ch/en/utils/location.html?building=CNB&floor=H&room=100.5&lang=en">CNB H 100.5</a>
 ---
 
 <h2>About me</h2>

--- a/_people/dana.html
+++ b/_people/dana.html
@@ -3,7 +3,7 @@ title: Dana Drachsler-Cohen
 position: Post-Doc
 image: dana.jpg    
 email: dana.drachsler@inf.ethz.ch
-office: CNB H100.5 
+office: <a href="https://ethz.ch/en/utils/location.html?building=CNB&floor=H&room=100.5&lang=en">CNB H 100.5</a> 
 website: 
 phone:
 cv:

--- a/_people/dimitadi.html
+++ b/_people/dimitadi.html
@@ -3,7 +3,7 @@ title: Dimitar I. Dimitrov
 position: direct doctorate student
 image: dimitadi.jpg
 email: dimitar.iliev.dimitrov@inf.ethz.ch
-office: CAB H66
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=66&lang=en">CAB H 66</a>
 website:
 phone: 
 cv:  https://files.sri.inf.ethz.ch/website/people/dimitar/cv-dimitadi.pdf

--- a/_people/fiorella.html
+++ b/_people/fiorella.html
@@ -3,7 +3,7 @@ title: Fiorella Meyer
 position: Operations Manager
 image: fiorella.jpg
 email: fiorella.meyer@inf.ethz.ch
-office: CAB H86.3
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=86.3&lang=en">CAB H 86.3</a>
 website:
 phone: +41 44 632 82 09
 cv:

--- a/_people/gagandeep.html
+++ b/_people/gagandeep.html
@@ -3,7 +3,7 @@ title: Gagandeep Singh
 position: PhD Student
 image: ggn.jpg    
 email: gsingh@inf.ethz.ch
-office: CAB H86.1
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=86.1&lang=en">CAB H 86.1</a>
 website: https://ggndpsngh.github.io/
 phone: 
 cv:

--- a/_people/jasper.html
+++ b/_people/jasper.html
@@ -3,7 +3,7 @@ title: Jasper Dekoninck
 position: PhD student
 image: jasper.jpg    
 email: jasper.dekoninck@inf.ethz.ch
-office: CNB H 100.5
+office: <a href="https://ethz.ch/en/utils/location.html?building=CNB&floor=H&room=100.5&lang=en">CNB H 100.5</a>
 website: 
 cv:
 

--- a/_people/jingxuan.html
+++ b/_people/jingxuan.html
@@ -3,7 +3,7 @@ title: Dr. Jingxuan He
 position: Post-Doc
 image: jingxuan.jpg
 email: jingxuan.he@berkeley.edu
-office: CAB H 66
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=66&lang=en">CAB H 66</a>
 ---
 
 

--- a/_people/luca.html
+++ b/_people/luca.html
@@ -3,7 +3,7 @@ title: Luca Beurer-Kellner
 position: PhD Student
 image: luca.jpg    
 email: luca.beurer-kellner@inf.ethz.ch
-office: CNB H100.5 
+office: <a href="https://ethz.ch/en/utils/location.html?building=CNB&floor=H&room=100.5&lang=en">CNB H 100.5</a> 
 website: 
 phone: 
 cv:

--- a/_people/marc.html
+++ b/_people/marc.html
@@ -3,7 +3,7 @@ title: Marc Fischer
 position: PhD Student
 image: marc.jpg    
 email: marc.fischer@inf.ethz.ch
-office: CAB H86.1 
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=86.1&lang=en">CAB H 86.1</a> 
 website: http://marcfischer.at
 phone:
 cv:

--- a/_people/markVero.html
+++ b/_people/markVero.html
@@ -3,7 +3,7 @@ title: Mark Vero
 position: PhD student
 image: markVero.jpg    
 email: mark.vero@inf.ethz.ch
-office: CAB H 66
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=66&lang=en">CAB H 66</a>
 website: 
 cv:
 

--- a/_people/martin.html
+++ b/_people/martin.html
@@ -3,7 +3,7 @@ title: Prof. Dr. Martin Vechev
 position: Professor
 image: mveth.jpg    
 email: martin.vechev@inf.ethz.ch
-office: CAB H69.1
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=69.1&lang=en">CAB H 69.1</a>
 website: 
 phone: 
 cv:

--- a/_people/matthew.html
+++ b/_people/matthew.html
@@ -3,7 +3,7 @@ title: Matthew Mirman
 position: PhD Student
 image: matthew_mirman.jpg
 email: matthew.mirman@inf.ethz.ch
-office: CAB H 85.2
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=85.2&lang=en">CAB H 85.2</a>
 website: https://www.mirman.com/
 phone: +41798815363
 cv:

--- a/_people/max.html
+++ b/_people/max.html
@@ -3,7 +3,7 @@ title:  Dr. Maximilian Baader
 position: Post-Doc
 image: max.jpg
 email: mbaader@inf.ethz.ch
-office: CAB H 81.1
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=81.1&lang=en">CAB H 81.1</a>
 website: 
 phone:
 cv:

--- a/_people/mirella.html
+++ b/_people/mirella.html
@@ -3,7 +3,7 @@ title: Mirella Rutz
 position: Administration
 image: mirella.jpg 
 email: mirella.rutz@inf.ethz.ch
-office: CAB H86.3
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=86.3&lang=en">CAB H 86.3</a>
 website: 
 phone: +41 44 632 82 09
 cv:

--- a/_people/mislav.html
+++ b/_people/mislav.html
@@ -3,7 +3,7 @@ title: Dr. Mislav Balunović
 position: Post-Doc
 image: mislav.jpg
 email: mislav.balunovic@inf.ethz.ch
-office: CAB H 86.1
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=86.1&lang=en">CAB H 86.1</a>
 ---
 
 <h2>About me</h2>

--- a/_people/momchil.html
+++ b/_people/momchil.html
@@ -3,7 +3,7 @@ title: Momchil Peychev
 position: direct doctorate student
 image: momchil.jpg
 email: momchil.peychev@inf.ethz.ch
-office: CAB H66
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=66&lang=en">CAB H 66</a>
 website:
 phone: 
 cv:

--- a/_people/niels.html
+++ b/_people/niels.html
@@ -3,7 +3,7 @@ title: Niels Mündler
 position: PhD Student
 image: niels.jpg
 email: niels.muendler@inf.ethz.ch
-office: CAB H 66
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=66&lang=en">CAB H 66</a>
 ---
 
 <h2>About me</h2>

--- a/_people/nikola.html
+++ b/_people/nikola.html
@@ -3,7 +3,7 @@ title: Nikola Jovanović
 position: PhD student
 image: nikola.jpg    
 email: nikola.jovanovic@inf.ethz.ch
-office: CAB H66
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=66&lang=en">CAB H 66</a>
 website: 
 cv: https://files.sri.inf.ethz.ch/website/people/nikola/nikola_jovanovic_cv.pdf
 ---

--- a/_people/nikolakonstantinov.html
+++ b/_people/nikolakonstantinov.html
@@ -3,7 +3,7 @@ title: Dr. Nikola Konstantinov
 position: post doctoral researcher
 image: nikola2.jpg    
 email: nikolahristov.konstantinov@inf.ethz.ch
-office: CAB E74
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=E&room=74&lang=en">CAB E 74</a>
 website: https://nikolakon.github.io/
 cv: https://nikolakon.github.io/assets/Konstantinov_Nikola_CV.pdf
 

--- a/_people/pesho.html
+++ b/_people/pesho.html
@@ -3,7 +3,7 @@ title: Pesho Ivanov
 position: PhD Student
 image: pesho.jpg    
 email: petar.ivanov@inf.ethz.ch
-office: CAB H66
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=66&lang=en">CAB H 66</a>
 website: http://pesho.info/about/
 phone: 
 cv: https://github.com/petar-ivanov/cv/raw/master/CV-Petar-Ivanov.pdf

--- a/_people/petar.html
+++ b/_people/petar.html
@@ -3,7 +3,7 @@ title: Dr. Petar Tsankov
 position: Senior Researcher
 image: petar.png
 email: petar.tsankov@inf.ethz.ch
-office: CAB H81.1
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=81.1&lang=en">CAB H 81.1</a>
 research-projects: blockchain-security
 website: https://www.sri.inf.ethz.ch/people/petar
 phone:

--- a/_people/robin.html
+++ b/_people/robin.html
@@ -3,7 +3,7 @@ title: Robin Staab
 position: PhD student
 image: robin.jpg
 email: robin.staab@inf.ethz.ch
-office: CAB H 85.2
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=85.2&lang=en">CAB H 85.2</a>
 website: 
 cv:
 

--- a/_people/rudiger.html
+++ b/_people/rudiger.html
@@ -3,7 +3,7 @@ title: Rudiger Birkner
 position: PhD Student (co-advised with Laurent Vanbever)
 image: rudi.jpg 
 email: rbirkner@ethz.ch
-office: ETZ G 86
+office: <a href="https://ethz.ch/en/utils/location.html?building=ETZ&floor=G&room=86&lang=en">ETZ G 86</a>
 website: https://www.rbirkner.ch/
 phone: 	+41 44 63 27043
 cv:

--- a/_people/samuel.html
+++ b/_people/samuel.html
@@ -3,7 +3,7 @@ title: Dr. Samuel Steffen
 position: Postdoctoral Researcher
 image: sam.jpg
 email: samuel.steffen@inf.ethz.ch
-office: CNB H 100.5
+office: <a href="https://ethz.ch/en/utils/location.html?building=CNB&floor=H&room=100.5&lang=en">CNB H 100.5</a>
 website:
 phone:
 cv:

--- a/_people/timon.html
+++ b/_people/timon.html
@@ -3,7 +3,7 @@ title: Dr. Timon Gehr
 position: Established Researcher
 image: timon.jpg  
 email: timon.gehr@inf.ethz.ch
-office: CAB H 81.1
+office: <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=81.1&lang=en">CAB H 81.1</a>
 website: 
 phone: 
 cv:

--- a/_people/tobias.html
+++ b/_people/tobias.html
@@ -3,7 +3,7 @@ title: Dr. Tobias Bühler
 position: Post-Doc
 image: tobias.jpg    
 email: tobias.buehler@inf.ethz.ch
-office: CNB H 104.2
+office: <a href="https://ethz.ch/en/utils/location.html?building=CNB&floor=H&room=104.2&lang=en">CNB H 104.2</a>
 website: 
 cv:
 

--- a/_people/yuhao.html
+++ b/_people/yuhao.html
@@ -3,7 +3,7 @@ title: Yuhao Mao
 position: PhD student
 image: yuhao.jpg
 email: yuhao.mao@inf.ethz.ch
-office: CNB H 100.5
+office: <a href="https://ethz.ch/en/utils/location.html?building=CNB&floor=H&room=100.5&lang=en">CNB H 100.5</a>
 website: https://algebraloveme.github.io/about
 cv:
 

--- a/_teaching/atsr2012.html
+++ b/_teaching/atsr2012.html
@@ -9,7 +9,7 @@ ta: Veselin Raychev
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=81107&semkez=2012W&lang=en
 session-time-place: 
-lecture-time-place: Wed 9-11, CAB G56
+lecture-time-place: Wed 9-11, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=56&lang=en">CAB G 56</a>
 exercise-time-place: 
 credits: 4
 image: 

--- a/_teaching/bigcode18-ss.html
+++ b/_teaching/bigcode18-ss.html
@@ -8,7 +8,7 @@ lecturer: Prof. Dr. Martin Vechev
 ta: Dr. Veselin Raychev
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=122999&semkez=2018S
-session-time-place: Mon 16-18, CHN D48
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=48&lang=en">CHN D 48</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bigcode18.html
+++ b/_teaching/bigcode18.html
@@ -8,7 +8,7 @@ lecturer: Dr. Veselin Raychev
 ta: 
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=126278&semkez=2018W&ansicht=KATALOGDATEN&lang=en
-session-time-place: Mon 16-18, CAB G52
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bigcode19-fall.html
+++ b/_teaching/bigcode19-fall.html
@@ -8,7 +8,7 @@ lecturer: Dr. Veselin Raychev
 ta:
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=131038&semkez=2019W&ansicht=KATALOGDATEN&lang=en
-session-time-place: Mon 16-18, CAB G52
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bigcode19.html
+++ b/_teaching/bigcode19.html
@@ -8,7 +8,7 @@ lecturer: Dr. Veselin Raychev
 ta:
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?semkez=2019S&ansicht=KATALOGDATEN&lerneinheitId=128865&lang=en
-session-time-place: Mon 16-18, CAB G52
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bigcode20.html
+++ b/_teaching/bigcode20.html
@@ -8,7 +8,7 @@ lecturer: Dr. Veselin Raychev
 ta:
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?semkez=2019S&ansicht=KATALOGDATEN&lerneinheitId=128865&lang=en
-session-time-place: Mon 16-18, CAB G52
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bigcode21.html
+++ b/_teaching/bigcode21.html
@@ -8,7 +8,7 @@ lecturer: Dr. Veselin Raychev
 ta:
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=150647&semkez=2021S&ansicht=KATALOGDATEN&lang=en
-session-time-place: Mon 16-18, CAB G52 (online via zoom, check your email for link)
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a> (online via zoom, check your email for link)
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bigcode22.html
+++ b/_teaching/bigcode22.html
@@ -8,7 +8,7 @@ lecturer: Dr. Veselin Raychev
 ta: Marc Fischer, Mark Niklas Müller, Nikola Jovanović, Mislav Balunović, Luca Beurer-Kellner, Maximilian Baader, Matthew Mirman, Pesho Ivanov
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=158758&semkez=2022S&ansicht=LEHRVERANSTALTUNGEN&lang=en
-session-time-place: Mon 16-18, CAB G52 (not an online course, certain events will also be available over zoom, check your email for link)
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a> (not an online course, certain events will also be available over zoom, check your email for link)
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bigcode23.html
+++ b/_teaching/bigcode23.html
@@ -8,7 +8,7 @@ lecturer: Dr. Veselin Raychev
 ta: Marc Fischer, Nikola Jovanović, Mislav Balunović, Maximilian Baader, Mark Niklas Müller, Dr. Timon Gehr
 assistants:
 edoz: https://www.vorlesungen.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=168505&semkez=2023S&ansicht=LEHRVERANSTALTUNGEN&lang=en
-session-time-place: Mon 16-18, CAB G52 (not an online course, certain events will also be available over zoom, check your email for link)
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a> (not an online course, certain events will also be available over zoom, check your email for link)
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bsec2018-ss.html
+++ b/_teaching/bsec2018-ss.html
@@ -8,7 +8,7 @@ lecturer: Prof. Dr. Martin Vechev, Dr. Petar Tsankov, Dr. Dana Drachsler Cohen
 ta: Dimitar Dimitrov, Andrei Dan, Dr. Kari Kostiainen, Karl Wuest, Sinisa Matetic
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=122706&semkez=2018S&lang=en
-session-time-place: Fri 13-15, CHN G22
+session-time-place: Fri 13-15, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=G&room=22&lang=en">CHN G 22</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bsec2018.html
+++ b/_teaching/bsec2018.html
@@ -8,7 +8,7 @@ lecturer: Dr. Petar Tsankov
 ta: 
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=126308&semkez=2018W&ansicht=KATALOGDATEN&lang=en
-session-time-place: Wed 13-15, LFW B 3
+session-time-place: Wed 13-15, <a href="https://ethz.ch/en/utils/location.html?building=LFW&floor=B&room=3&lang=en">LFW B 3</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bsec2019-fall.html
+++ b/_teaching/bsec2019-fall.html
@@ -9,7 +9,7 @@ ta: Dimitar Dimitrov, Gagandeep Singh, Pesho Ivanov, Benjamin Bichsel, Samuel St
 
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=133167&semkez=2019W&ansicht=KATALOGDATEN&lang=en
-session-time-place: Wed 13-15, LFW B3
+session-time-place: Wed 13-15, <a href="https://ethz.ch/en/utils/location.html?building=LFW&floor=B&room=3&lang=en">LFW B 3</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/bsec2019.html
+++ b/_teaching/bsec2019.html
@@ -9,7 +9,7 @@ ta: Dimitar Dimitrov, Gagandeep Singh, Pesho Ivanov, Benjamin Bichsel, Samuel St
 
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=128870&semkez=2019S&ansicht=KATALOGDATEN&lang=en
-session-time-place: Fri 13-15, CAB G57
+session-time-place: Fri 13-15, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=57&lang=en">CAB G 57</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/mlis2016.html
+++ b/_teaching/mlis2016.html
@@ -8,7 +8,7 @@ lecturer: O. Hilliges, Martin Vechev
 ta: 
 assistants: Fabrizio Pece, Stefan Stevsic, Jie Song, Emre Aksan, Petar Tsankov, Pavol Bielik, Timon Gehr, Dimitar Dimitrov
 edoz: 
-session-time-place: Wed 15-17, CHN D 46
+session-time-place: Wed 15-17, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=46&lang=en">CHN D 46</a>
 lecture-time-place: 
 exercise-time-place: 
 credits: 2

--- a/_teaching/pa2013.html
+++ b/_teaching/pa2013.html
@@ -9,7 +9,7 @@ ta: Andrei Dan
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=85849&semkez=2013W&lang=en
 session-time-place: 
-lecture-time-place: Wed 9-11, CHN D46
+lecture-time-place: Wed 9-11, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=46&lang=en">CHN D 46</a>
 exercise-time-place: 
 credits: 4
 image: assets/images/gears.jpeg

--- a/_teaching/pa2015.html
+++ b/_teaching/pa2015.html
@@ -9,7 +9,7 @@ ta: Veselin Raychev, Andrei Dan
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=98480&semkez=2015S&lang=en
 session-time-place: 
-lecture-time-place: Thu 13:15-15:00, ML F38
+lecture-time-place: Thu 13:15-15:00, <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=F&room=38&lang=en">ML F 38</a>
 exercise-time-place: 
 credits: 4
 image: assets/images/gears.jpeg

--- a/_teaching/pa2016.html
+++ b/_teaching/pa2016.html
@@ -9,7 +9,7 @@ ta: Dimitar Dimitrov, Pavol Bielik
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=104754&semkez=2016S&lang=en
 session-time-place: 
-lecture-time-place: Mon 13-16, CAB G51
+lecture-time-place: Mon 13-16, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=51&lang=en">CAB G 51</a>
 exercise-time-place: 
 credits: 6
 image: assets/images/gears.jpeg

--- a/_teaching/pa2017.html
+++ b/_teaching/pa2017.html
@@ -9,7 +9,7 @@ ta: Dimitar Dimitrov, Petar Tsankov
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=112813&semkez=2017S&lang=en
 session-time-place: 
-lecture-time-place: Mon 13-16, CAB G51
+lecture-time-place: Mon 13-16, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=51&lang=en">CAB G 51</a>
 exercise-time-place: 
 credits: 6
 image: assets/images/gears.jpeg

--- a/_teaching/pass2018.html
+++ b/_teaching/pass2018.html
@@ -9,8 +9,8 @@ ta: Dr. Petar Tsankov, Dr. Dana Drachsler-Cohen, Timon Gehr, Gagandeep Singh
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=122698&semkez=2018S&lang=en
 session-time-place:
-lecture-time-place: Mon 13-15, CAB G61
-exercise-time-place: Mon 15-16, CAB G61
+lecture-time-place: Mon 13-15, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=61&lang=en">CAB G 61</a>
+exercise-time-place: Mon 15-16, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=61&lang=en">CAB G 61</a>
 credits: 5
 image: assets/images/pass.png
 

--- a/_teaching/pass2019.html
+++ b/_teaching/pass2019.html
@@ -9,8 +9,8 @@ ta: Dr. Petar Tsankov, Matthew Mirman, Maximilian Baader, Dimitar Dimitrov
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=129091&semkez=2019S&ansicht=KATALOGDATEN&lang=en
 session-time-place:
-lecture-time-place: Mon 13-15, CAB G61
-exercise-time-place: Mon 15-16, CAB G61
+lecture-time-place: Mon 13-15, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=61&lang=en">CAB G 61</a>
+exercise-time-place: Mon 15-16, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=61&lang=en">CAB G 61</a>
 credits: 5
 image: assets/images/pass.png
 

--- a/_teaching/pl2013.html
+++ b/_teaching/pl2013.html
@@ -8,7 +8,7 @@ lecturer: Martin Vechev, Peter Müller
 ta: 
 assistants: 
 edoz: 
-session-time-place: Tue 13-15, CAB H53
+session-time-place: Tue 13-15, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=53&lang=en">CAB H 53</a>
 lecture-time-place: 
 exercise-time-place: 
 credits: 2

--- a/_teaching/pp2018.html
+++ b/_teaching/pp2018.html
@@ -9,7 +9,7 @@ ta: Pavol Bielik, Timo Schneider
 assistants: "Pesho Ivanov, Salvatore di Girolamo, Niels Gleinig, Alexandros Nikolaos Ziogas, Johannes de Fine Licht, Alen Stojanov, Tyler Smith, Boss Mike, Felix Schmetz, Mickey Vänskä, Nicolas Ochsner, Srdan Krstic"
 edoz:
 session-time-place:
-lecture-time-place: Tue	10-12, ML D 28; Wed 13-15, HG F 5
+lecture-time-place: Tue	10-12, <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=D&room=28&lang=en">ML D 28</a>; Wed 13-15, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=F&room=5&lang=en">HG F 5</a>
 exercise-time-place: Wed 15-17 or Fri 10-12
 credits:
 image: assets/images/orator.jpg
@@ -21,12 +21,12 @@ image: assets/images/orator.jpg
 	21.2.2018: <a href="http://bit.ly/2EHdPMS" target=_blank>Group Assignment is Online</a></br>
 	27.3.2018: [Week 6] Due to Easter the students from Friday exercises can attend an exercise on Wednesday (28.3). The groups are merged as follows:</br>
 	<ul>
-		<li>Fri 10-12 HG G 26.5 -> Wed 15-17 CHN E 46</li>
-		<li>Fri 10-12 ETZ G 91 -> Wed 15-17 ML J 34.1</li>
-		<li>Fri 10-12 LFW E 13 -> Wed 15-17 CHN E 42</li>
-		<li>Fri 10-12 NO D 11 -> Wed 15-17 ML J 34.3</li>
-		<li>Fri 10-12 NO E 11 -> Wed 15-17 ETZ J 91</li>
-		<li>Wed 15-17 ETZ H 91 -> Wed 15-17 ETZ F 91</li>
+		<li>Fri 10-12 <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=G&room=26.5&lang=en">HG G 26.5</a> -> Wed 15-17 <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=E&room=46&lang=en">CHN E 46</a></li>
+		<li>Fri 10-12 <a href="https://ethz.ch/en/utils/location.html?building=ETZ&floor=G&room=91&lang=en">ETZ G 91</a> -> Wed 15-17 <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=J&room=34.1&lang=en">ML J 34.1</a></li>
+		<li>Fri 10-12 <a href="https://ethz.ch/en/utils/location.html?building=LFW&floor=E&room=13&lang=en">LFW E 13</a> -> Wed 15-17 <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=E&room=42&lang=en">CHN E 42</a></li>
+		<li>Fri 10-12 <a href="https://ethz.ch/en/utils/location.html?building=NO&floor=D&room=11&lang=en">NO D 11</a> -> Wed 15-17 <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=J&room=34.3&lang=en">ML J 34.3</a></li>
+		<li>Fri 10-12 <a href="https://ethz.ch/en/utils/location.html?building=NO&floor=E&room=11&lang=en">NO E 11</a> -> Wed 15-17 <a href="https://ethz.ch/en/utils/location.html?building=ETZ&floor=J&room=91&lang=en">ETZ J 91</a></li>
+		<li>Wed 15-17 <a href="https://ethz.ch/en/utils/location.html?building=ETZ&floor=H&room=91&lang=en">ETZ H 91</a> -> Wed 15-17 <a href="https://ethz.ch/en/utils/location.html?building=ETZ&floor=F&room=91&lang=en">ETZ F 91</a></li>
 	</ul>
 </p>
 

--- a/_teaching/pp2019.html
+++ b/_teaching/pp2019.html
@@ -9,7 +9,7 @@ ta: Pavol Bielik, Timo Schneider
 assistants: "Johannes de Fine Licht, Marcin Copik, Shigang Li, Yishai Oltchik, Konstantin Taranov, Salvatore Di Girolamo, Samuel Steffen, Marc Fisher, Alexandra Bugariu, Guilherme Miguel Teixeira Rito"
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?semkez=2019S&ansicht=KATALOGDATEN&lerneinheitId=127706&lang=en
 session-time-place:
-lecture-time-place: Tue	10-12, ML D 28 (Video Projection in ML E 12); Wed 13-15, HG F 7 (Video Projection in HG F 5)
+lecture-time-place: Tue	10-12, <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=D&room=28&lang=en">ML D 28</a> (Video Projection in <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=E&room=12&lang=en">ML E 12</a>); Wed 13-15, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=F&room=7&lang=en">HG F 7</a> (Video Projection in <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=F&room=5&lang=en">HG F 5</a>)
 exercise-time-place: Wed 15-17 or Fri 10-12
 credits:
 image: assets/images/orator.jpg

--- a/_teaching/ps2014.html
+++ b/_teaching/ps2014.html
@@ -8,7 +8,7 @@ lecturer: Martin Vechev, Peter Müller
 ta: 
 assistants: 
 edoz: 
-session-time-place: Tue 13-15, CAB H53
+session-time-place: Tue 13-15, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=53&lang=en">CAB H 53</a>
 lecture-time-place: 
 exercise-time-place: 
 credits: 2

--- a/_teaching/riai2017.html
+++ b/_teaching/riai2017.html
@@ -9,8 +9,8 @@ ta: Dr. Petar Tsankov, Dr. Dana Drachsler-Cohen, Dimitar Dimitrov, Matthew Mirma
 assistants: 
 edoz: http://www.vvz.ethz.ch/lerneinheitPre.do?semkez=2017W&lerneinheitId=118940&lang=en
 session-time-place: 
-lecture-time-place: Tue 10-12, HG E3
-exercise-time-place: Tue 14-15, HG F26.3; Wed 11-12, CAB G59
+lecture-time-place: Tue 10-12, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=E&room=3&lang=en">HG E 3</a>
+exercise-time-place: Tue 14-15, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=F&room=26.3&lang=en">HG F 26.3</a>; Wed 11-12, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=59&lang=en">CAB G 59</a>
 credits: 4
 image: assets/images/ai.png
 

--- a/_teaching/riai2018.html
+++ b/_teaching/riai2018.html
@@ -9,8 +9,8 @@ ta: Dr. Petar Tsankov, Dr. Dana Drachsler-Cohen, Benjamin Bichsel, Samuel Steffe
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?semkez=2018W&ansicht=KATALOGDATEN&lerneinheitId=123752&lang=en
 session-time-place:
-lecture-time-place: Mon 10-12, HG D 7.2
-exercise-time-place: Mon 13-14, LFW C4 or Wed 11-12 CAB G59
+lecture-time-place: Mon 10-12, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=D&room=7.2&lang=en">HG D 7.2</a>
+exercise-time-place: Mon 13-14, <a href="https://ethz.ch/en/utils/location.html?building=LFW&floor=C&room=4&lang=en">LFW C 4</a> or Wed 11-12 <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=59&lang=en">CAB G 59</a>
 credits: 4
 image: assets/images/ai.png
 ---

--- a/_teaching/riai2019.html
+++ b/_teaching/riai2019.html
@@ -9,8 +9,8 @@ ta: Dr. Petar Tsankov, Benjamin Bichsel, Samuel Steffen, Gagandeep Singh, Mislav
 assistants:
 edoz: http://vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=131566&semkez=2019W&ansicht=KATALOGDATEN&lang=de
 session-time-place:
-lecture-time-place: Wed 15-17, HG G 3
-exercise-time-place: Mon 13-14, LFW C4 or Wed 11-12 CAB G59
+lecture-time-place: Wed 15-17, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=G&room=3&lang=en">HG G 3</a>
+exercise-time-place: Mon 13-14, <a href="https://ethz.ch/en/utils/location.html?building=LFW&floor=C&room=4&lang=en">LFW C 4</a> or Wed 11-12 <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=59&lang=en">CAB G 59</a>
 credits: 5
 image: assets/images/ai.png
 ---

--- a/_teaching/rse-fall2016.html
+++ b/_teaching/rse-fall2016.html
@@ -8,7 +8,7 @@ lecturer: Prof. Dr. Martin Vechev
 ta: Petar Tsankov
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?semkez=2016W&lang=en&ansicht=KATALOGDATEN&lerneinheitId=109450
-session-time-place: Wed 10-12, CHN D46
+session-time-place: Wed 10-12, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=46&lang=en">CHN D 46</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/rse-spr2016.html
+++ b/_teaching/rse-spr2016.html
@@ -8,7 +8,7 @@ lecturer: Prof. Dr. Martin Vechev
 ta: Andrei Dan
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=105040&semkez=2016S&lang=en
-session-time-place: Mon 16-18, CHN D 48
+session-time-place: Mon 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=48&lang=en">CHN D 48</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/rse2019.html
+++ b/_teaching/rse2019.html
@@ -9,8 +9,8 @@ ta: Benjamin Bichsel, Inna Grijnevitch, Jingxuan He, Dr. Dana Drachsler-Cohen
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=127250&semkez=2019S&ansicht=KATALOGDATEN&lang=en
 session-time-place:
-lecture-time-place: Mon 10-12, CAB G61; Wed 10-12, CAB G61
-exercise-time-place: Mon 13-16, HG D3.2; Tue 15-18, ML E12; Thu 15-18, ML H41.1
+lecture-time-place: Mon 10-12, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=61&lang=en">CAB G 61</a>; Wed 10-12, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=61&lang=en">CAB G 61</a>
+exercise-time-place: Mon 13-16, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=D&room=3.2&lang=en">HG D 3.2</a>; Tue 15-18, <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=E&room=12&lang=en">ML E 12</a>; Thu 15-18, <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=H&room=41.1&lang=en">ML H 41.1</a>
 credits: 8
 image: assets/images/sae.png
 

--- a/_teaching/rse2022.html
+++ b/_teaching/rse2022.html
@@ -41,7 +41,7 @@ Students apply the learned techniques to solve a group project in the area of pr
 <p><strong>Lectures</strong></p>
 <ul>
     <li>Lectures will be held <b>online</b>: they will be pre-recorded and published here in advance (credentials can be found <a href="https://moodle-app2.let.ethz.ch/mod/forum/discuss.php?d=96993">here</a>). We recommend watching these during regular lecture hours.</li>
-    <li>There will be <b>no</b> in-presence live streaming. In particular, the lecture hall (HG F 3) will not be used.</li>
+    <li>There will be <b>no</b> in-presence live streaming. In particular, the lecture hall (<a href="https://ethz.ch/en/utils/location.html?building=HG&floor=F&room=3&lang=en">HG F 3</a>) will not be used.</li>
     <li>Each <strong>Wed at 13:40-14:00</strong>, the lecturers offer an online Q&A session
         (<a href="https://ethz.zoom.us/j/61929002539">Zoom link</a> <sup>&#9733;</sup>) on the topics of that week. Q&amp;A sessions will not be recorded.</li>
 </ul>
@@ -52,7 +52,7 @@ Students apply the learned techniques to solve a group project in the area of pr
     </li>
     <li>Exercise sessions start in the <strong>second week</strong> of the semester. There will be both online and physical exercise sessions, as listed below (students can freely chose which session to attend). We will discuss the solutions of the previous week's exercise sheet.
         <ul>
-            <li>Group 1 (Mon 14-16): Physical in ML F 34</li>
+            <li>Group 1 (Mon 14-16): Physical in <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=F&room=34&lang=en">ML F 34</a></li>
             <li>Group 2 (Mon 16-18): Online via <a href="https://ethz.zoom.us/j/62713084901">Zoom</a> <sup>&#9733;</sup> </li>
             <li><s>Group 3 (Thu 16-18): Online via Zoom</s> (merged with group 4)</li>
             <li>Groups 3 + 4 (Thu 16-18): Online via <a href="https://ethz.zoom.us/j/62012698382">Zoom</a> <sup>&#9733;</sup> </li>

--- a/_teaching/rtai22.html
+++ b/_teaching/rtai22.html
@@ -11,8 +11,8 @@ head-ta: Benjamin Bichsel
 head-ta-details: use <a href="https://moodle-app2.let.ethz.ch/course/view.php?id=17747">Moodle</a> for questions unless they contain sensitive information
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=163199&semkez=2022W&ansicht=LEHRVERANSTALTUNGEN&lang=de
 session-time-place:
-lecture-time-place: Wed 14-16, HG G3 (<a href="https://video.ethz.ch/lectures/d-infk/2022/autumn/263-2400-00L.html">physical recordings</a>, <a href="https://moodle-app2.let.ethz.ch/mod/forum/discuss.php?d=111857">virtual recordings</a>)
-exercise-time-place: Mon 12-14 (<a href="https://ethz.zoom.us/j/64912324222">Zoom</a>) or Wed 12-14 (CAB G 51)
+lecture-time-place: Wed 14-16, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=G&room=3&lang=en">HG G 3</a> (<a href="https://video.ethz.ch/lectures/d-infk/2022/autumn/263-2400-00L.html">physical recordings</a>, <a href="https://moodle-app2.let.ethz.ch/mod/forum/discuss.php?d=111857">virtual recordings</a>)
+exercise-time-place: Mon 12-14 (<a href="https://ethz.zoom.us/j/64912324222">Zoom</a>) or Wed 12-14 (<a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=51&lang=en">CAB G 51</a>)
 credits: 6
 image: assets/images/reliableai_logo.png
 ---
@@ -397,7 +397,7 @@ href="https://exams.vis.ethz.ch/">exam collection</a> of the student association
 <p><strong>Lectures</strong></p>
 
 <ul>
-	<li>The lecture will take place physically in room HG G3, but will be recorded.</li>
+	<li>The lecture will take place physically in room <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=G&room=3&lang=en">HG G 3</a>, but will be recorded.</li>
 	<li>
 		For additional questions, we have prepared a <a
 		href="https://moodle-app2.let.ethz.ch/course/view.php?id=17747">Moodle

--- a/_teaching/rtai23.html
+++ b/_teaching/rtai23.html
@@ -11,8 +11,8 @@ head-ta: Nikola Jovanović
 head-ta-details: use <a href="https://moodle-app2.let.ethz.ch/course/view.php?id=20673">Moodle</a> for questions unless they contain sensitive information
 edoz: https://www.vorlesungen.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?semkez=2023W&ansicht=LEHRVERANSTALTUNGEN&lerneinheitId=172754&lang=de
 session-time-place:
-lecture-time-place: Wed 14-16, HG G3 (<a href="https://video.ethz.ch/">recordings on the ETH video portal</a>)
-exercise-time-place: Mon 12-14, CAB G 56 or Wed 12-14, CAB G 51
+lecture-time-place: Wed 14-16, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=G&room=3&lang=en">HG G 3</a> (<a href="https://video.ethz.ch/">recordings on the ETH video portal</a>)
+exercise-time-place: Mon 12-14, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=56&lang=en">CAB G 56</a> or Wed 12-14, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=51&lang=en">CAB G 51</a>
 credits: 6
 image: assets/images/reliableai_logo.png
 ---
@@ -411,7 +411,7 @@ href="https://exams.vis.ethz.ch/">exam collection</a> of the student association
 <p><strong>Lectures</strong></p>
 
 <ul>
-	<li>The lecture will take place physically in room HG G3, but will be recorded.</li>
+	<li>The lecture will take place physically in room <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=G&room=3&lang=en">HG G 3</a>, but will be recorded.</li>
 	<li>
 		For additional questions, we have prepared a <a
 		href="https://moodle-app2.let.ethz.ch/course/view.php?id=20673">Moodle

--- a/_teaching/rtai24.html
+++ b/_teaching/rtai24.html
@@ -11,8 +11,8 @@ head-ta: Nikola Jovanović
 head-ta-details: use <a href="https://moodle-app2.let.ethz.ch/course/view.php?id=23528">Moodle</a> for questions unless they contain sensitive information
 edoz: https://www.vorlesungen.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=182765&semkez=2024W&ansicht=LEHRVERANSTALTUNGEN&lang=de
 session-time-place:
-lecture-time-place: Wed 14-16, HG G3 (<a href="https://video.ethz.ch/">recordings on the ETH video portal</a>)
-exercise-time-place: Mon 12-14, CAB G 56 or Wed 12-14, CAB G 51
+lecture-time-place: Wed 14-16, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=G&room=3&lang=en">HG G 3</a> (<a href="https://video.ethz.ch/">recordings on the ETH video portal</a>)
+exercise-time-place: Mon 12-14, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=56&lang=en">CAB G 56</a> or Wed 12-14, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=51&lang=en">CAB G 51</a>
 credits: 6
 image: assets/images/reliableai_logo.png
 ---
@@ -397,7 +397,7 @@ image: assets/images/reliableai_logo.png
 <p><strong>Lectures</strong></p>
 
 <ul>
-	<li>The lecture will take place physically in room HG G3, but will be recorded.</li>
+	<li>The lecture will take place physically in room <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=G&room=3&lang=en">HG G 3</a>, but will be recorded.</li>
 	<li>
 		For additional questions, we have prepared a <a
 			href="https://moodle-app2.let.ethz.ch/course/view.php?id=23528">Moodle

--- a/_teaching/sae2018.html
+++ b/_teaching/sae2018.html
@@ -9,8 +9,8 @@ ta: Federico Poli, Matthew Mirman, Benjamin Bichsel
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=119792&semkez=2018S&lang=en
 session-time-place:
-lecture-time-place: Mon 10-12, CAB G61; Wed 10-12, CAB G61
-exercise-time-place: Mon 13-16, CHN D44; Tue 15-18, ML E12; Thu 15-18, ETZ F91
+lecture-time-place: Mon 10-12, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=61&lang=en">CAB G 61</a>; Wed 10-12, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=61&lang=en">CAB G 61</a>
+exercise-time-place: Mon 13-16, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=44&lang=en">CHN D 44</a>; Tue 15-18, <a href="https://ethz.ch/en/utils/location.html?building=ML&floor=E&room=12&lang=en">ML E 12</a>; Thu 15-18, <a href="https://ethz.ch/en/utils/location.html?building=ETZ&floor=F&room=91&lang=en">ETZ F 91</a>
 credits: 8
 image: assets/images/sae.png
 

--- a/_teaching/ses2013.html
+++ b/_teaching/ses2013.html
@@ -8,7 +8,7 @@ lecturer: Martin Vechev, Torsten Hoefler
 ta: Andrei Dan
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheitPre.do?lerneinheitId=86428&semkez=2013W&lang=en
-session-time-place: Wed 13-15, HG E 22
+session-time-place: Wed 13-15, <a href="https://ethz.ch/en/utils/location.html?building=HG&floor=E&room=22&lang=en">HG E 22</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/ses2018.html
+++ b/_teaching/ses2018.html
@@ -8,7 +8,7 @@ lecturer: Prof. Dr. Martin Vechev, Dr. Dana Drachsler Cohen
 ta:
 assistants:
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=124898&semkez=2018W&ansicht=KATALOGDATEN&lang=en
-session-time-place: Mon 13-15, CHN G46
+session-time-place: Mon 13-15, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=G&room=46&lang=en">CHN G 46</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/ses2022-fall.html
+++ b/_teaching/ses2022-fall.html
@@ -9,7 +9,7 @@ head-ta: Jingxuan He, Dimitar I. Dimitrov, Chengyu Zhang
 ta: Anouk Paradis, Momchil Peychev, Luca Beurer-Kellner, Samuel Steffen, Benjamin Bichsel, Shaohua Li, Theo Theodoridis, Dominik Winterer, Sverrir Thorgeirsson, Zu-Ming Jiang
 assistants: 
 edoz: http://www.vvz.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?semkez=2022W&lerneinheitId=163725&lang=en
-session-time-place: Wed 16-18, CHN D 42
+session-time-place: Wed 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=42&lang=en">CHN D 42</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/ses2023-fall.html
+++ b/_teaching/ses2023-fall.html
@@ -9,7 +9,7 @@ head-ta: Dimitar I. Dimitrov, Chengyu Zhang
 ta: Momchil Peychev, Luca Beurer-Kellner, Jingxuan He, Robin Staab, Jasper Dekoninck, Shaohua Li, Thodoris Sotiropoulos, Theo Theodoridis, Sverrir Thorgeirsson, Zu-Ming Jiang, Yann Girsberger
 assistants: 
 edoz: https://www.vorlesungen.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?semkez=2023W&lerneinheitId=173654&lang=en
-session-time-place: Wed 16-18, CHN D 42
+session-time-place: Wed 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=42&lang=en">CHN D 42</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/ses2023.html
+++ b/_teaching/ses2023.html
@@ -9,7 +9,7 @@ ta: Dimitar I. Dimitrov, Momchil Peychev, Jingxuan He, Benjamin Bichsel, Anouk P
 
 assistants: 
 edoz: https://www.vorlesungen.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=168753&semkez=2023S&lang=en
-session-time-place: Thu 12-14, CAB G52
+session-time-place: Thu 12-14, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/ses2024-fall.html
+++ b/_teaching/ses2024-fall.html
@@ -9,7 +9,7 @@ head-ta: Niels Mündler, Chengyu Zhang
 ta: Jasper Dekoninck, Momchil Peychev, Robin Staab, Mark Vero, Michel Weber, Shaohua Li, Thodoris Sotiropoulos, Timon Gehr, Sverrir Thorgeirsson, Zuming Jiang, Hao Sun
 assistants: 
 edoz: https://www.vorlesungen.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?semkez=2024W&ansicht=LEHRVERANSTALTUNGEN&lerneinheitId=183600&lang=en
-session-time-place: Wed 16-18, CHN D 42
+session-time-place: Wed 16-18, <a href="https://ethz.ch/en/utils/location.html?building=CHN&floor=D&room=42&lang=en">CHN D 42</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/_teaching/ses2024.html
+++ b/_teaching/ses2024.html
@@ -10,7 +10,7 @@ ta: Anouk Paradis, Luca Beurer-Kellner, Robin Staab, Jasper Dekoninck, Michel We
 
 assistants: 
 edoz: https://www.vorlesungen.ethz.ch/Vorlesungsverzeichnis/lerneinheit.view?lerneinheitId=178199&semkez=2024S&lang=en
-session-time-place: Thu 12-14, CAB G52
+session-time-place: Thu 12-14, <a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=G&room=52&lang=en">CAB G 52</a>
 lecture-time-place:
 exercise-time-place:
 credits: 2

--- a/contact.html
+++ b/contact.html
@@ -15,7 +15,7 @@ permalink: /contact/index.html
       	ETH Zürich <br/>
 		Department of Computer Science <br/>
 		Secure, Reliable, and Intelligent Systems Lab <br/>
-		CAB H69.1<br/>
+		<a href="https://ethz.ch/en/utils/location.html?building=CAB&floor=H&room=69.1&lang=en">CAB H 69.1</a><br/>
 		Universitätstrasse 6<br/>
 		8092 Zürich<br/>
 		Switzerland <br/>

--- a/replace_rauminfo.py
+++ b/replace_rauminfo.py
@@ -1,0 +1,41 @@
+"""
+Wrap all mentions of a room in a link to the room's location page.
+
+common formats for rooms:
+CAB G 56
+CAB G56
+HG F 81.1
+HG F81.1
+note: can be any ALLCAPS SINGLE LETTER DIGITS combination
+
+Link format:
+https://ethz.ch/en/utils/location.html?building=LFW&floor=C&room=5&lang=en
+"""
+
+import re
+import os
+
+# match mentions of rooms, skip if they are in a link
+room_regex = re.compile(r"(?<!\>)(?P<space>\s+|\(\s*|,\s*)(?P<building>[A-Z]+)\s(?P<floor>[A-Z])\s?(?P<room>\d+(\.\d+)?)")
+
+# walk the tree and find all files
+for root, dirs, files in os.walk("."):
+    for file in files:
+        if file.endswith(".html"):
+            with open(os.path.join(root, file), "r") as f:
+                content = f.read()
+
+            printed = False
+            # find all mentions of a room
+            # propose to user to replace each match with the link
+            for match in room_regex.finditer(content):
+                if not printed:
+                    print(file)
+                    printed = True
+                print(match.groupdict())
+                # replace the match with the link
+                content = content.replace(match.group(0), f"{match.group('space')}<a href=\"https://ethz.ch/en/utils/location.html?building={match.group('building')}&floor={match.group('floor')}&room={match.group('room')}&lang=en\">{match.group('building')} {match.group('floor')} {match.group('room')}</a>")
+
+            # write the content back to the file
+            with open(os.path.join(root, file), "w") as f:
+                f.write(content)


### PR DESCRIPTION
Normalize the usage of room names (`BUILDING<SPACE>FLOOR<SPACE>NUMBER`) and adds a link to the roomfinder.

Before I push this big change would like to clarify if this is useful/desired. Also might be nice to write a proper jekyll script but idk how to do this so I just pushed the python script that I used.